### PR TITLE
Add pyproject.toml to the api package so it can be installed

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "api"
+dynamic = ["version"]
+dependencies = []
+requires-python = ">= 3.10"
+authors = [
+    {name = "Balsa Bulatović"},
+    {name = "Teodor Vidaković"},
+    {name = "Vladimir Popov"},
+]
+
+[tool.setuptools.package-dir]
+api = "./"


### PR DESCRIPTION
This PR adds a `pyproject.toml` to the `api` package so it can be installed. This enables other components of the app to access the package.