### PR TITLE
Simple viusalizer support for node ids that contain hashes

### DIFF
--- a/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
+++ b/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
@@ -97,7 +97,7 @@
             .style('stroke', 'black')
             .style('stroke-width', '1.5px')
             .each(function(d) {
-                d3.select("g#"+d.name)
+                d3.select("g[id=\""+d.name+"\"]")
                 .append('text')
                 .attr('text-anchor','middle')
                 .attr('font-size',textSize)


### PR DESCRIPTION
This PR fixes a bug which led to node ids not being displayed in the simple visualizer if they contained hash symbols.
Merge after #38 

Closes #20 