### PR TITLE
Feature: Filtering

### DIFF
--- a/core-sok/src/core/filters/operator_filter.py
+++ b/core-sok/src/core/filters/operator_filter.py
@@ -101,6 +101,8 @@ class OperatorFilter(Filter):
         """
         nodes = list(filter(lambda node: self.satisfiesQuery(node), graph.nodes))
         edges = list(filter(lambda edge: edge.src in nodes and edge.dest in nodes, graph.edges))
+        for node in nodes:
+            node.edges = list(filter(lambda edge: edge.src in nodes and edge.dest in nodes, node.edges))
         return Graph(edges, nodes)
 
     def to_json(self) -> dict:

--- a/core-sok/src/core/filters/operator_filter.py
+++ b/core-sok/src/core/filters/operator_filter.py
@@ -74,7 +74,7 @@ class OperatorFilter(Filter):
 
     def to_json(self) -> dict:
         return {
-            "type": "AttributeFilter",
+            "type": "OperatorFilter",
             "attribute": self.attribute,
             "operator": self.operator,
             "value": self.value

--- a/core-sok/src/core/filters/operator_filter.py
+++ b/core-sok/src/core/filters/operator_filter.py
@@ -31,7 +31,7 @@ class OperatorFilter(Filter):
 
     def satisfiesQuery(self, node: Node) -> bool:
         """
-        Chcecks if the node satisfies the query.
+        Checks if the node satisfies the query.
         :param node: The node to check.
         :type node: Node
         :return: True if the node satisfies the query, False otherwise. 

--- a/core-sok/src/core/filters/operator_filter.py
+++ b/core-sok/src/core/filters/operator_filter.py
@@ -18,14 +18,15 @@ class OperatorFilter(Filter):
         "<": lambda a, b: a < b,
         ">=": lambda a, b: a >= b,
         "<=": lambda a, b: a <= b,
-        "in": lambda a, b: b in a,
-        "re": lambda a, regex: search(regex, a) is not None,
-        "⋮": lambda a, b: a % b == 0,
+        "contains": lambda a, b: b in a,
+        "matches": lambda a, regex: search(regex, a) is not None,
+        "divisible by": lambda a, b: a % b == 0,
     }
 
     def __init__(self, attribute: str, operator_name: str, value: str, operator: Callable[[Any, Any], bool]):
         """
         Initializes the operator filter.
+        The value will be converted to the type of the attribute once filter is called.
 
         :param attribute: The attribute to filter by.
         :type attribute: str
@@ -45,6 +46,7 @@ class OperatorFilter(Filter):
         """
         Initializes the operator filter.
         The operator is determined by the operator_name.
+        The value will be converted to the type of the attribute once filter is called.
 
         :param attribute: The attribute to filter by.
         :type attribute: str
@@ -81,9 +83,12 @@ class OperatorFilter(Filter):
         except ValueError:
             return False
 
-        if self.attribute == "id":
-            return self.operator(node.id, self.value)
-        return self.operator(node.data[self.attribute], self.value)
+        try:
+            if self.attribute == "id":
+                return self.operator(node.id, self.value)
+            return self.operator(node.data[self.attribute], self.value)
+        except (ValueError, TypeError):
+            return False
 
     def filter(self, graph: Graph) -> Graph:
         """

--- a/core-sok/src/core/filters/operator_filter.py
+++ b/core-sok/src/core/filters/operator_filter.py
@@ -1,0 +1,82 @@
+from api.models.graph import Graph
+from .base_filter import Filter
+from api.models.node import Node
+
+
+class OperatorFilter(Filter):
+    """
+    OperatorFilter filters the graph so only nodes that contain a specific
+    attribute for which the given comparison returns true remain in the graph.
+    """
+
+    def __init__(self, attribute: str, operator: str, value: str):
+        """
+        Initializes the attribute filter.
+
+        :param attribute: The attribute to filter by.
+        :type attribute: str
+        :param operator: The operator to use.
+        :type operator: str
+        :param value: The value to compare to.
+        :type value: str
+        """
+        self.attribute = attribute
+        self.operator = operator
+        self.value = value
+    
+    def __eq__(self, __value: object) -> bool:
+        if not isinstance(__value, OperatorFilter):
+            return False
+        return self.attribute == __value.attribute and self.operator == __value.operator and self.value == __value.value
+
+    def satisfiesQuery(self, node: Node) -> bool:
+        """
+        Chcecks if the node satisfies the query.
+        :param node: The node to check.
+        :type node: Node
+        :return: True if the node satisfies the query, False otherwise. 
+        """
+        if self.attribute not in node.data:
+            return False
+
+        try:
+            self.value = type(node.data[self.attribute])(self.value)
+        except ValueError:
+            return False
+
+        if self.operator == "==":
+            return node.data[self.attribute] == self.value
+        if self.operator == "!=":
+            return node.data[self.attribute] != self.value
+        if self.operator == ">":
+            return node.data[self.attribute] > self.value
+        if self.operator == "<":
+            return node.data[self.attribute] < self.value
+        if self.operator == ">=":
+            return node.data[self.attribute] >= self.value
+        if self.operator == "<=":
+            return node.data[self.attribute] <= self.value
+
+        return False
+
+    def filter(self, graph: Graph) -> Graph:
+        """
+        Filters the graph.
+
+        :param graph: The graph to filter.
+        :type graph: Graph
+        :return: The filtered graph.
+        :rtype: Graph
+        """
+        nodes = list(filter(lambda node: self.satisfiesQuery(node), graph.nodes))
+        edges = list(filter(lambda edge: edge.src in nodes and edge.dest in nodes, graph.edges))
+        return Graph(edges, nodes)
+
+    def to_json(self) -> dict:
+        return {
+            "type": "AttributeFilter",
+            "attribute": self.attribute,
+            "operator": self.operator,
+            "value": self.value
+        }
+

--- a/core-sok/src/core/filters/operator_filter_tests.py
+++ b/core-sok/src/core/filters/operator_filter_tests.py
@@ -1,0 +1,62 @@
+
+import unittest
+from .operator_filter import OperatorFilter
+from api.models.graph import Graph
+from api.models.node import Node
+from api.models.edge import Edge
+
+class OperatorFilterTests(unittest.TestCase):
+    def test_all_nodes_pass(self):
+        node1 = Node("1", {"name": "node1"})
+        node2 = Node("2", {"name": "node2"})
+        node3 = Node("3", {"name": "node3"})
+        edge1 = Edge(None, node1, node2)
+        edge2 = Edge(None, node2, node3)
+        graph = Graph([edge1, edge2], [node1, node2, node3])
+        search_filter = OperatorFilter("name", "!=", 1)
+        filtered_graph = search_filter.filter(graph)
+        self.assertEqual(filtered_graph.get_nodes(), [node1, node2, node3])
+        self.assertEqual(filtered_graph.get_edges(), [edge1, edge2])
+        self.assertNotEqual(filtered_graph, graph)
+
+    def test_no_node_passes(self):
+        node1 = Node("1", {"name": "node1"})
+        node2 = Node("2", {"name": "node2"})
+        node3 = Node("3", {"name": "node3"})
+        edge1 = Edge(None, node1, node2)
+        edge2 = Edge(None, node2, node3)
+        graph = Graph([edge1, edge2], [node1, node2, node3])
+        search_filter = OperatorFilter("name", "==", 1)
+        filtered_graph = search_filter.filter(graph)
+        self.assertEqual(filtered_graph.get_nodes(), [])
+        self.assertEqual(filtered_graph.get_edges(), [])
+        self.assertNotEqual(filtered_graph, graph)
+
+    def test_string_comparison(self):
+        node1 = Node("1", {"name": "node1"})
+        node2 = Node("2", {"name": "node2"})
+        node3 = Node("3", {"name": "node3"})
+        edge1 = Edge(None, node1, node2)
+        edge2 = Edge(None, node2, node3)
+        graph = Graph([edge1, edge2], [node1, node2, node3])
+        search_filter = OperatorFilter("name", "<=", "node2")
+        filtered_graph = search_filter.filter(graph)
+        self.assertEqual(filtered_graph.get_nodes(), [node1, node2])
+        self.assertEqual(filtered_graph.get_edges(), [edge1])
+        self.assertNotEqual(filtered_graph, graph)
+    
+    def test_no_attribute(self):
+        node1 = Node("1", {"name": "node1"})
+        node2 = Node("2", {"name": "node2"})
+        node3 = Node("3", {"name": "node3"})
+        edge1 = Edge(None, node1, node2)
+        edge2 = Edge(None, node2, node3)
+        graph = Graph([edge1, edge2], [node1, node2, node3])
+        search_filter = OperatorFilter("age", "==", "node1")
+        filtered_graph = search_filter.filter(graph)
+        self.assertEqual(filtered_graph.get_nodes(), [])
+        self.assertEqual(filtered_graph.get_edges(), [])
+        self.assertNotEqual(filtered_graph, graph)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/core-sok/src/core/filters/search_filter.py
+++ b/core-sok/src/core/filters/search_filter.py
@@ -33,6 +33,8 @@ class SearchFilter(Filter):
         """
         nodes = list(filter(lambda node: self.search_term in node, graph.nodes))
         edges = list(filter(lambda edge: edge.src in nodes and edge.dest in nodes, graph.edges))
+        for node in nodes:
+            node.edges = list(filter(lambda edge: edge.src in nodes and edge.dest in nodes, node.edges))
         return Graph(edges, nodes)
 
     def to_json(self) -> dict:

--- a/graph_explorer/src/graph_explorer/graph_visualizer/module/content.py
+++ b/graph_explorer/src/graph_explorer/graph_visualizer/module/content.py
@@ -2,6 +2,7 @@ from api.components.data_source import DataSource
 from api.components.visualizer import Visualizer
 from api.models.graph import Graph
 from ..models import Workspace
+from core.filters.operator_filter import OperatorFilter
 
 
 class ContentModule:
@@ -39,7 +40,8 @@ class ContentModule:
             "content": self.current_visualizer.display(self.get_filtered_graph()) if self.current_visualizer else None,
             "workspaces": [vars(ws) for ws in self.workspaces],
             "active_ws_id": self.workspace_id,
-            "filters": list(map(lambda filter: filter.to_json(), self.get_current_workspace().get_filters())) if self.workspace_id != ContentModule.INVALID_WORKSPACE_ID else []
+            "filters": list(map(lambda filter: filter.to_json(), self.get_current_workspace().get_filters())) if self.workspace_id != ContentModule.INVALID_WORKSPACE_ID else [],
+            "operators": list(OperatorFilter.operators.keys())
         }
         return content
 

--- a/graph_explorer/src/graph_explorer/graph_visualizer/static/style.css
+++ b/graph_explorer/src/graph_explorer/graph_visualizer/static/style.css
@@ -56,11 +56,11 @@ a .material-symbols-outlined {
 }
 
 #filter-attribute-input, #filter-value-input {
-    width: 45%;
+    width: 42.5%;
 }
 
 .filter-form .select {
-    width: 9.2%;
+    width: 15%;
 }
 
 .filter-form .select select{

--- a/graph_explorer/src/graph_explorer/graph_visualizer/templates/index.html
+++ b/graph_explorer/src/graph_explorer/graph_visualizer/templates/index.html
@@ -58,29 +58,35 @@
             {% endif %}
         </div>
         <div class="panel-block">
-          <span class="filter-form">
-            <input id="filter-attribute-input" class="input" type="text" placeholder="Attribute" />
+          <form class="filter-form" method="POST" action="{% url 'add_filter' %}">
+            {% csrf_token %}
+            <input name="attribute" id="filter-attribute-input" class="input" type="text" placeholder="Attribute" />
             <div class="select">
-              <select>
-                <option>&lt;</option>
-                <option>&gt;</option>
-                <option>&lt;=</option>
-                <option>&gt;=</option>
-                <option>==</option>
-                <option>!=</option>
+              <select name="operator">
+                <option value="<">&lt;</option>
+                <option value=">">&gt;</option>
+                <option value="<=">&lt;=</option>
+                <option value=">=">&gt;=</option>
+                <option value="==">==</option>
+                <option value="!=">!=</option>
               </select>
             </div>
-            <input id="filter-value-input" class="input" type="text" placeholder="Value" />
-            <button class="button is-light">Filter</button>
-          </span>
+            <input name="value" id="filter-value-input" class="input" type="text" placeholder="Value" />
+            <input type="submit" value="Filter" class="button is-light" />
+          </form>
         </div>
         <div class="panel-block">
           <div class="active-filters">
             <span>Active filters:</span>
             {% for filter in filters %}
-              {% if filter.type == 'SearchFilter' %}
-                <div class="filter has-background-primary has-text-white" onclick="deleteFilter({{ filter|safe }})">{{ filter.search_term }} <span class="material-symbols-outlined">remove</span></div>
-              {% endif %}
+                <div class="filter has-background-primary has-text-white" onclick="deleteFilter({{ filter|safe }})">
+                  {% if filter.type == 'SearchFilter' %}
+                    {{ filter.search_term }}
+                  {% elif filter.type == 'OperatorFilter' %}
+                    {{ filter.attribute }} {{ filter.operator }} {{ filter.value }}
+                  {% endif %}
+                  <span class="material-symbols-outlined">remove</span>
+                </div>
             {% endfor %}
           </div>
         </div>

--- a/graph_explorer/src/graph_explorer/graph_visualizer/templates/index.html
+++ b/graph_explorer/src/graph_explorer/graph_visualizer/templates/index.html
@@ -63,12 +63,9 @@
             <input name="attribute" id="filter-attribute-input" class="input" type="text" placeholder="Attribute" />
             <div class="select">
               <select name="operator">
-                <option value="<">&lt;</option>
-                <option value=">">&gt;</option>
-                <option value="<=">&lt;=</option>
-                <option value=">=">&gt;=</option>
-                <option value="==">==</option>
-                <option value="!=">!=</option>
+                {% for operator in operators %}
+                  <option value="{{operator|safe}}">{{operator}}</option>
+                {% endfor %}
               </select>
             </div>
             <input name="value" id="filter-value-input" class="input" type="text" placeholder="Value" />

--- a/graph_explorer/src/graph_explorer/graph_visualizer/urls.py
+++ b/graph_explorer/src/graph_explorer/graph_visualizer/urls.py
@@ -40,4 +40,5 @@ urlpatterns = [
     path("provide-data", views.provide_data, name="provide_data"),
     path("search", views.search, name="search"),
     path("delete-filter", views.delete_filter, name="delete_filter"),
+    path("add-filter", views.add_filter, name="add_filter"),
 ]

--- a/graph_explorer/src/graph_explorer/graph_visualizer/views.py
+++ b/graph_explorer/src/graph_explorer/graph_visualizer/views.py
@@ -10,6 +10,7 @@ from .services import *
 from .models import Workspace
 from .module.content import ContentModule
 from core.filters.search_filter import SearchFilter
+from core.filters.operator_filter import OperatorFilter
 
 content_module = ContentModule(
     apps.get_app_config("graph_visualizer").data_source_plugins,
@@ -124,7 +125,23 @@ def delete_filter(request):
         if filter_json["type"] == "SearchFilter":
             search_filter = SearchFilter(filter_json["search_term"])
             current_workspace.get_filter_chain().remove_filter(search_filter)
+        elif filter_json["type"] == "OperatorFilter":
+            operator_filter = OperatorFilter(filter_json["attribute"], filter_json["operator"], filter_json["value"])
+            current_workspace.get_filter_chain().remove_filter(operator_filter)
     except KeyError:
         return
 
     return HttpResponse(200, content_type="application/json")
+
+def add_filter(request):
+    try:
+        attribute: str = request.POST["attribute"]
+        operator: str = request.POST["operator"]
+        value: str = request.POST["value"]
+        current_workspace = content_module.get_current_workspace()
+        operator_filter: OperatorFilter = OperatorFilter(attribute, operator, value)
+        current_workspace.add_filter(operator_filter)
+    except (KeyError, ValueError):
+        return
+
+    return HttpResponseRedirect(reverse('index'))

--- a/graph_explorer/src/graph_explorer/graph_visualizer/views.py
+++ b/graph_explorer/src/graph_explorer/graph_visualizer/views.py
@@ -67,8 +67,8 @@ def workspace(request, workspace_id):
     active_workspace: Workspace = list(
         filter(lambda ws: ws.id == workspace_id, app_config.workspaces)
     )[0]
-    tree_view_data = get_tree_view_data(active_workspace.graph)
-    nodes_dict = get_node_dict(active_workspace.graph)
+    tree_view_data = get_tree_view_data(active_workspace.get_filtered_graph())
+    nodes_dict = get_node_dict(active_workspace.get_filtered_graph())
 
     content_module.workspaces = app_config.workspaces
     content_module.workspace_id = workspace_id


### PR DESCRIPTION
This PR adds a filter that filters the graph so only nodes that have an attribute that pass a given comparison are kept. If a node does not contain the attribute the filter compares, it fails the filter.
This new `OperatorFilter` should support comparisons between both strings and numbers.

Merge after #38 and #41 
Closes #9 