### PR TITLE
Add Support for Undirected Graphs in Advanced Visualizer

### DIFF
--- a/advanced_visualizer/src/advanced_visualizer/implementation.py
+++ b/advanced_visualizer/src/advanced_visualizer/implementation.py
@@ -27,20 +27,22 @@ class AdvancedVisualizer(Visualizer):
         except Exception as e:
             return f"<html><body><h2>Error: Invalid graph data.</h2><p>Details: {e}</p></body></html>"
 
-        return self.template.render(nodes=graph.get_nodes(), edges=graph.get_edges(), name=self.get_name())
+        return self.template.render(nodes=graph.get_nodes(), edges=graph.get_edges(), name=self.get_name(),
+                                    directed=graph.directed)
 
 
 class MockGraph(Graph):
     def get_nodes(self):
         # Create mock nodes with IDs and labels
-        return [Node(id=str(i), data={"label": f"Node {i}", "extraInfo": f"Info {i}", "info2": f"Info {i}"}) for i in range(1, 21)]
+        return [Node(id=str(i), data={"label": f"Node {i}", "extraInfo": f"Info {i}", "info2": f"Info {i}"}) for i in
+                range(1, 21)]
 
     def get_edges(self):
         # Create mock edges between nodes with some data
         edges = []
         for i in range(1, 10):  # Creating edges from each node to the next
             edges.append(Edge(src=Node(id=str(i), data={"label": f"Node {i}"}),
-                              dest=Node(id=str(i+1), data={"label": f"Node {i+1}"}),
+                              dest=Node(id=str(i + 1), data={"label": f"Node {i + 1}"}),
                               data={"weight": i}))
 
         edges.append(Edge(src=Node(id=str(1), data={"label": "Node 1"}),
@@ -49,6 +51,12 @@ class MockGraph(Graph):
         edges.append(Edge(src=Node(id=str(20), data={"label": "Node 20"}),
                           dest=Node(id=str(1), data={"label": "Node 1"}),
                           data={"weight": 10}))
+        edges.append(Edge(src=Node(id=str(1), data={"label": "Node 1"}),
+                          dest=Node(id=str(10), data={"label": "Node 10"}),
+                          data={"weight": 5}))
+        edges.append(Edge(src=Node(id=str(10), data={"label": "Node 10"}),
+                          dest=Node(id=str(1), data={"label": "Node 1"}),
+                          data={"weight": 2}))
         return edges
 
 
@@ -57,4 +65,3 @@ if __name__ == "__main__":
     mock_graph = MockGraph()
     html_output = visualizer.display(mock_graph)
     print(html_output)
-

--- a/advanced_visualizer/src/templates/advanced_visualizer.html
+++ b/advanced_visualizer/src/templates/advanced_visualizer.html
@@ -17,14 +17,14 @@
 }
 
 .active-node rect {
-  stroke-width: 2px; /* Make the stroke width larger for better visibility */
-  fill: #e5e4e4; /* Use a distinct fill color for active nodes */
+  stroke-width: 2px;
+  fill: #e5e4e4;
 }
 
-/* Consider adding hover styles for better interactivity */
+
 .node:hover rect {
-  fill: #e6f7ff; /* Light fill on hover */
-  stroke: #b3daff; /* Light stroke on hover */
+  fill: #e6f7ff;
+  stroke: #b3daff;
   cursor: pointer;
 }
 
@@ -32,18 +32,14 @@
 <script src="https://d3js.org/d3.v7.js"></script>
 <script>
     function nodeClick(event, d) {
-    // Prevent any default action
+
     event.preventDefault();
 
-    // Reset the style of any previously active node
     d3.selectAll(".active-node rect")
       .style("fill", "white");
 
-    // Remove the active-node class from all nodes
     d3.selectAll(".active-node").classed("active-node", false);
 
-    // Add the active-node class to the clicked node and update its style
-    // Use d3.select(this) or d3.select(event.currentTarget) to select the clicked element
     d3.select(event.currentTarget)
       .classed("active-node", true)
       .select("rect")
@@ -55,194 +51,223 @@
 </svg>
 <div id="tooltip" class="tooltip" style="position: absolute; display: none; padding: 10px; background: rgba(0, 0, 0, 0.6); color: white; border-radius: 5px; font-size: 16px; pointer-events: none; min-width: 100px;"></div>
 <script>
-    var nodes = [
-        {% for n in nodes %}
-        {
-            name: "node_{{n.id}}",
-            data: {{ n.data | tojson }},
-        },
-        {% endfor %}
-    ];
 
-    var links = [
-        {% for e in edges %}
-        {
-            source: "node_{{e.src.id}}",
-            target: "node_{{e.dest.id}}",
-            data: {{ e.data | tojson }},
-        },
-        {% endfor %}
-    ];
+    function renderAdvancedGraph() {
+        var nodes = [
+            {% for n in nodes %}
+            {
+                name: "node_{{n.id}}",
+                data: {{ n.data | tojson }},
+                id: "{{ n.id }}",
+            },
+                {% endfor %}
+        ];
 
-    links = links.map(link => ({
-        ...link,
-        source: nodes.find(n => n.name === link.source),
-        target: nodes.find(n => n.name === link.target),
-    }));
+        var links = [
+            {% for e in edges %}
+            {
+                source: "node_{{e.src.id}}",
+                target: "node_{{e.dest.id}}",
+                data: {{ e.data | tojson }},
+            },
+            {% endfor %}
+        ];
 
-    var svg = d3.select('#main-svg-advanced-visualizer');
-    var g = svg.append('g');
+        var directed = {{ directed | tojson }};
 
-    var zoom = d3.zoom()
-        .on("zoom", function (event) {
-            g.attr("transform", event.transform);
+        links = links.map(link => ({
+            ...link,
+            source: nodes.find(n => n.name === link.source),
+            target: nodes.find(n => n.name === link.target),
+        }));
+
+        var svg = d3.select('#main-svg-advanced-visualizer');
+        var g = svg.append('g');
+
+        var zoom = d3.zoom()
+            .on("zoom", function (event) {
+                g.attr("transform", event.transform);
+            });
+
+        svg.call(zoom);
+
+        console.log(nodes);
+        console.log(links);
+        console.log(directed);
+
+        var addedLinks = new Map();
+
+        var linksFiltered = links.filter(function(link) {
+            let linkKey = link.source.id + "-" + link.target.id;
+            let reverseLinkKey = link.target.id + "-" + link.source.id;
+
+            if (!directed) {
+                if (addedLinks.has(linkKey) || addedLinks.has(reverseLinkKey)) {
+                    console.log("Duplicate link found: ", linkKey);
+                    return false;
+                }
+            }
+
+            addedLinks.set(linkKey, true);
+            return true;
         });
 
-    svg.call(zoom);
+         // Initialize a map to track links between the same nodes
+        var linkCounts = {};
 
-    console.log(nodes);
-    console.log(links);
+        linksFiltered.forEach(function(link) {
+            var key = link.source.id + "-" + link.target.id;
+            var reverseKey = link.target.id + "-" + link.source.id;
 
-    var simulation = d3.forceSimulation(nodes)
-    .force("link", d3.forceLink(links).id(function(d) { return d.id; }).distance(300))
-    .force("charge", d3.forceManyBody().strength(100))
-    .force("center", d3.forceCenter(700 / 2, 700 / 2))
-    .force("gravity", d3.forceManyBody().strength(-100))
-        .force("collide", d3.forceCollide().radius(80))
-    .on("tick", tick);
+            if (!linkCounts[key] && !linkCounts[reverseKey]) {
+                linkCounts[key] = 0;
+            }else if(linkCounts[reverseKey]){
+                key = reverseKey;
+            }
 
-    function drag(simulation) {
-        function dragstarted(event) {
-          if (!event.active) simulation.alphaTarget(0.3).restart();
-          event.subject.fx = event.subject.x;
-          event.subject.fy = event.subject.y;
+            linkCounts[key]++;
+            link.index = linkCounts[key];
+        });
+        console.log(linkCounts);
+        console.log(linksFiltered);
+
+        var simulation = d3.forceSimulation(nodes)
+        .force("link", d3.forceLink(linksFiltered).id(function(d) { return d.id; }).distance(300))
+        .force("charge", d3.forceManyBody().strength(100))
+        .force("center", d3.forceCenter(700 / 2, 700 / 2))
+        .force("gravity", d3.forceManyBody().strength(-100))
+            .force("collide", d3.forceCollide().radius(80))
+        .on("tick", tick);
+
+        var tooltip = d3.select("#tooltip");
+
+        function showTooltip(event, d) {
+          var dataStrings = Object.entries(d.data).map(function([key, value]) {
+            return `${key}: ${value}`;
+          });
+
+          var tooltipText = dataStrings.join("<br>");
+
+          tooltip
+            .html(tooltipText)
+            .style('display', 'inline-block')
+            .style('left', (event.pageX + 10) + 'px')
+            .style('top', (event.pageY + 10) + 'px');
         }
 
-        function dragged(event) {
-          event.subject.fx = event.x;
-          event.subject.fy = event.y;
+        function hideTooltip() {
+          tooltip.style('display', 'none');
         }
 
-        function dragended(event) {
-          if (!event.active) simulation.alphaTarget(0);
-          event.subject.fx = null;
-          event.subject.fy = null;
+        // Function to generate a path for each link
+        function linkPath(d) {
+            var dx = d.target.x - d.source.x,
+                dy = d.target.y - d.source.y,
+                dr = Math.sqrt(dx * dx + dy * dy) * d.index; // Increase the curvature based on the link's index
+
+            return "M" + d.source.x + "," + d.source.y + "A" + dr + "," + dr + " 0 0,1 " + d.target.x + "," + d.target.y;
         }
 
-        return d3.drag()
-          .on("start", dragstarted)
-          .on("drag", dragged)
-          .on("end", dragended);
-    }
+        var link = g.selectAll('.link')
+        .data(linksFiltered)
+        .enter().append('path')
+        .attr('class', 'link')
+        .style('stroke-width', d => d.data.weight ? 1 + d.data.weight * 0.5 : 1)
+        .attr('d', linkPath)
+        .on('mouseover', showTooltip)
+        .on('mouseout', hideTooltip);
 
-    // Assuming the tooltip element already exists in your HTML/CSS with id="tooltip"
-    var tooltip = d3.select("#tooltip");
+        var node = g.selectAll('.node')
+        .data(nodes)
+        .enter().append('g')
+        .attr('class', 'node')
+        .attr('id', d => d.name)
+        .call(drag(simulation))
+        .on('click', nodeClick)
+        .on('mouseover', showTooltip)
+        .on('mouseout', hideTooltip);
 
-    function showTooltip(event, d) {
-      var dataStrings = Object.entries(d.data).map(function([key, value]) {
-        return `${key}: ${value}`;
-      });
+        var rectWidth = 100; // Width of the rectangle
+        var initialRectHeight = 30; // Initial height of the rectangle
+        var textSize = 12; // Size of the text
+        var lineSpacing = 15; // Spacing between lines of text
 
-      var tooltipText = dataStrings.join("<br>");
+        node.each(function(d) {
+            var nodeGroup = d3.select(this);
+            var keys = Object.keys(d.data);
 
-      tooltip
-        .html(tooltipText)
-        .style('display', 'inline-block')
-        .style('left', (event.pageX + 10) + 'px')
-        .style('top', (event.pageY + 10) + 'px');
-    }
+            var totalTextLines = 1 + keys.length; // 1 for the name, rest for data keys
+            var totalHeightNeeded = textSize + (totalTextLines * lineSpacing);
 
-    function hideTooltip() {
-      tooltip.style('display', 'none');
-    }
+            // Adjust the rectangle height to fit all text
+            var rectHeight = Math.max(initialRectHeight, totalHeightNeeded + 10);
 
-    // Initialize a map to track links between the same nodes
-    var linkCounts = {};
+            // Append rectangle
+            nodeGroup.append('rect')
+                .attr('width', rectWidth)
+                .attr('height', rectHeight)
+                .attr('x', -rectWidth / 2)
+                .attr('y', -rectHeight / 2)
+                .style('fill', 'white')
+                .style("stroke", "#9ecae1")
+                .style('stroke-width', '1.5px');
 
-    links.forEach(function(link) {
-        var key = link.source.id + "-" + link.target.id;
-        var reverseKey = link.target.id + "-" + link.source.id;
+            var startYPosition = -rectHeight / 2 + (rectHeight - totalHeightNeeded) / 2 + textSize;
 
-        if (!linkCounts[key] && !linkCounts[reverseKey]) {
-            linkCounts[key] = 0;
-        }
-
-        linkCounts[key]++;
-        link.index = linkCounts[key];
-    });
-
-    // Function to generate a path for each link
-    function linkPath(d) {
-        var dx = d.target.x - d.source.x,
-            dy = d.target.y - d.source.y,
-            dr = Math.sqrt(dx * dx + dy * dy) * d.index; // Increase the curvature based on the link's index
-
-        return "M" + d.source.x + "," + d.source.y + "A" + dr + "," + dr + " 0 0,1 " + d.target.x + "," + d.target.y;
-    }
-
-    var link = g.selectAll('.link')
-    .data(links)
-    .enter().append('path')
-    .attr('class', 'link')
-    .style('stroke-width', d => d.data.weight ? 1 + d.data.weight * 0.5 : 1)
-    .attr('d', linkPath)
-    .on('mouseover', showTooltip)
-    .on('mouseout', hideTooltip);
-
-    var node = g.selectAll('.node')
-    .data(nodes)
-    .enter().append('g')
-    .attr('class', 'node')
-    .attr('id', d => d.name)
-    .call(drag(simulation))
-    .on('click', nodeClick)
-    .on('mouseover', showTooltip)
-    .on('mouseout', hideTooltip);
-
-    var rectWidth = 100; // Width of the rectangle
-    var initialRectHeight = 30; // Initial height of the rectangle
-    var textSize = 12; // Size of the text
-    var lineSpacing = 15; // Spacing between lines of text
-
-    node.each(function(d) {
-        var nodeGroup = d3.select(this);
-        var keys = Object.keys(d.data);
-
-        var totalTextLines = 1 + keys.length; // 1 for the name, rest for data keys
-        var totalHeightNeeded = textSize + (totalTextLines * lineSpacing);
-
-        // Adjust the rectangle height to fit all text
-        var rectHeight = Math.max(initialRectHeight, totalHeightNeeded + 10);
-
-        // Append rectangle
-        nodeGroup.append('rect')
-            .attr('width', rectWidth)
-            .attr('height', rectHeight)
-            .attr('x', -rectWidth / 2)
-            .attr('y', -rectHeight / 2)
-            .style('fill', 'white')
-            .style("stroke", "#9ecae1")
-            .style('stroke-width', '1.5px');
-
-        var startYPosition = -rectHeight / 2 + (rectHeight - totalHeightNeeded) / 2 + textSize;
-
-        // Append name text first
-        nodeGroup.append('text')
-            .attr('text-anchor', 'middle')
-            .attr('x', 0)
-            .attr('y', startYPosition)
-            .attr('font-size', textSize + 'px')
-            .attr('font-family', 'sans-serif')
-            .attr('fill', '#9ecae1')
-            .text(d.name);
-
-        // Append data texts below the name text
-        keys.forEach((key, index) => {
+            // Append name text first
             nodeGroup.append('text')
                 .attr('text-anchor', 'middle')
                 .attr('x', 0)
-                .attr('y', startYPosition + (lineSpacing * (index + 1)))
+                .attr('y', startYPosition)
                 .attr('font-size', textSize + 'px')
                 .attr('font-family', 'sans-serif')
-                .attr('fill', 'gray')
-                .text(key + ": " + d.data[key]);
+                .attr('fill', '#9ecae1')
+                .text(d.name);
+
+            // Append data texts below the name text
+            keys.forEach((key, index) => {
+                nodeGroup.append('text')
+                    .attr('text-anchor', 'middle')
+                    .attr('x', 0)
+                    .attr('y', startYPosition + (lineSpacing * (index + 1)))
+                    .attr('font-size', textSize + 'px')
+                    .attr('font-family', 'sans-serif')
+                    .attr('fill', 'gray')
+                    .text(key + ": " + d.data[key]);
+            });
         });
-    });
 
 
-    function tick() {
-    node.attr("transform", d => `translate(${d.x},${d.y})`);
-    link.attr("d", linkPath);
+        function tick() {
+        node.attr("transform", d => `translate(${d.x},${d.y})`);
+        link.attr("d", linkPath);
+        }
+
+        function drag(simulation) {
+            function dragstarted(event) {
+              if (!event.active) simulation.alphaTarget(0.3).restart();
+              event.subject.fx = event.subject.x;
+              event.subject.fy = event.subject.y;
+            }
+
+            function dragged(event) {
+              event.subject.fx = event.x;
+              event.subject.fy = event.y;
+            }
+
+            function dragended(event) {
+              if (!event.active) simulation.alphaTarget(0);
+              event.subject.fx = null;
+              event.subject.fy = null;
+            }
+
+            return d3.drag()
+              .on("start", dragstarted)
+              .on("drag", dragged)
+              .on("end", dragended);
+        }
     }
 
+renderAdvancedGraph();
+    
 </script>


### PR DESCRIPTION
### DESCRIPTION
This pull request introduces a significant enhancement to our advanced graph visualizer, focusing on robust support for undirected graphs. The goal is to accurately represent undirected graphs by ensuring that edges between nodes are showed correctly without duplication.

_Features and Improvements_
- **Duplicate Edge Filtering**: Implemented a new filtering mechanism that identifies and eliminates duplicate edges in undirected graphs, ensuring each pair of connected nodes is represented by a single, bidirectional edge.

_Additional Note_
In addition to implementing support for undirected graphs in the Advanced Visualizer, this pull request also includes some code refactoring aimed at improving the maintainability of codebase.

### BEFORE
![image](https://github.com/MomirMilutinovic/graph-expressiveness-team-6/assets/104560670/cf0af943-e8fe-40c1-b649-392ab555025d)

### AFTER
![image](https://github.com/MomirMilutinovic/graph-expressiveness-team-6/assets/104560670/1aeae1bf-b0fe-43fa-ac55-ba9bb3505f4f)


Closes #16 