### PR TITLE
Simple visualizer arrowheads

### DIFF
--- a/simple_visualizer/src/simple_visualizer/implementation.py
+++ b/simple_visualizer/src/simple_visualizer/implementation.py
@@ -15,4 +15,4 @@ class SimpleVisualizer(Visualizer):
         return "simple_visualizer"
 
     def display(self, graph: Graph) -> str:
-        return self.template.render(nodes=graph.get_nodes(), edges=graph.get_edges(), name=self.get_name())
+        return self.template.render(nodes=graph.get_nodes(), edges=graph.get_edges(), name=self.get_name(), directed=graph.directed)

--- a/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
+++ b/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
@@ -63,6 +63,19 @@
         const handleZoom = (e) => g.attr('transform', e.transform);
         const zoom = d3.zoom().on('zoom', handleZoom);
 
+        d3.select('#main-svg-{{name}}').append('defs')
+            .append('marker')
+            .attr("id", "arrowhead")
+            .attr("viewBox", "0 -5 10 10")
+            .attr("refX", 43)
+            .attr("refY", 0)
+            .attr("markerWidth", 8)
+            .attr("markerHeight", 8)
+            .attr("orient", "auto")
+            .append("path")
+            .attr("fill", "#9ecae1")
+            .attr("d", 'M0,-5L10,0L0,5');
+
         var g = d3.select('#main-svg-{{name}}').call(zoom).append('g');
 
         const simulation = d3.forceSimulation(nodes)
@@ -76,6 +89,9 @@
         const link = g.selectAll(".link")
             .data(links).enter()
             .append("line")
+            {% if directed %}
+            .attr("marker-end", 'url(#arrowhead)')
+            {% endif %}
             .attr("class" , "link");
     
         const node = g.selectAll(".node")


### PR DESCRIPTION
This PR enhances the simple visualizer by displaying arrowheads at the ends of links in directed graphs.
Closes #20 
Screenshot:
![image](https://github.com/MomirMilutinovic/graph-expressiveness-team-6/assets/40830508/3b61acfb-a721-45b2-9792-14d6f1264b8d)

