### PR TITLE
Decrease gravity in simple visualizer

### DIFF
--- a/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
+++ b/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
@@ -92,10 +92,10 @@
         var g = d3.select('#main-svg-{{name}}').call(zoom).append('g');
 
         const simulation = d3.forceSimulation(nodes)
-            .force("charge", d3.forceManyBody().strength(-100))
             .force("link", d3.forceLink(links).distance(300))
-            .force("x", d3.forceX(600))
-            .force("y", d3.forceY(300))    
+            .force("charge", d3.forceManyBody().strength(100))
+            .force("center", d3.forceCenter(700 / 2, 700 / 2))
+            .force("gravity", d3.forceManyBody().strength(-100))
             .force("collide", d3.forceCollide().radius(80))
             .on("tick", tick);
 


### PR DESCRIPTION
This PR makes nodes displayed by the simple visualizer less tightly packed so the visualization does not flicker in dense large and dense graphs.

Closes #20 