### PR TITLE
Don't display the names of focused nodes in bold in simple visualizer

### DIFF
--- a/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
+++ b/simple_visualizer/src/simple_visualizer/templates/simple_visualizer_template.html
@@ -17,7 +17,6 @@
 }
 
 .active-node {
-    stroke: black;
     stroke-width: 2px;
 }
 


### PR DESCRIPTION
This PR makes focused nodes in the simple visualizer slightly more readable by not displaying them in bold.
Closes #20 